### PR TITLE
fix: remove Service Worker

### DIFF
--- a/site/.eleventy.js
+++ b/site/.eleventy.js
@@ -1,5 +1,6 @@
 module.exports = (config) => {
   config.addPassthroughCopy('src/css');
+  config.addPassthroughCopy('src/sw.js');
   config.addPassthroughCopy('src/images');
   config.addPassthroughCopy('src/downloads');
 

--- a/site/src/sw.js
+++ b/site/src/sw.js
@@ -1,0 +1,14 @@
+self.addEventListener('install', function (e) {
+  self.skipWaiting();
+});
+
+self.addEventListener('activate', function (e) {
+  self.registration
+    .unregister()
+    .then(function () {
+      return self.clients.matchAll();
+    })
+    .then(function (clients) {
+      clients.forEach((client) => client.navigate(client.url));
+    });
+});


### PR DESCRIPTION
this will unregister the Service Worker that’s causing the site to load the old version until you hard refresh